### PR TITLE
michael/LAZ-122 teamcity playmode tests

### DIFF
--- a/Assets/_Laz/Tests/LazBoostTests.cs
+++ b/Assets/_Laz/Tests/LazBoostTests.cs
@@ -34,7 +34,7 @@ namespace Tests
         {
             for (int i = 0; i < 5; i++)
             {
-                yield return new WaitForEndOfFrame();
+                yield return new WaitForFixedUpdate();
             }
             var originalPosition = Vector3.zero;
             var expectedBoostSpeed = 30f;
@@ -60,7 +60,7 @@ namespace Tests
         {
             for (int i = 0; i < 5; i++)
             {
-                yield return new WaitForEndOfFrame();
+                yield return new WaitForFixedUpdate();
             }
             var originalPosition = Vector3.zero;
             var expectedLazoSpeed = 11f;

--- a/Assets/_Laz/Tests/LazModelTests.cs
+++ b/Assets/_Laz/Tests/LazModelTests.cs
@@ -27,7 +27,7 @@ namespace Tests
         {
             for (int i = 0; i < 5; i++)
             {
-                yield return new WaitForEndOfFrame();
+                yield return new WaitForFixedUpdate();
             }
 
             var lazCoordinatorBehaviour = GameObject.FindObjectOfType<LazCoordinatorBehaviour>();
@@ -43,7 +43,7 @@ namespace Tests
         {
             for (int i = 0; i < 5; i++)
             {
-                yield return new WaitForEndOfFrame();
+                yield return new WaitForFixedUpdate();
             }
 
             var lazCoordinatorBehaviour = GameObject.FindObjectOfType<LazCoordinatorBehaviour>();
@@ -59,7 +59,7 @@ namespace Tests
         {
             for (int i = 0; i < 5; i++)
             {
-                yield return new WaitForEndOfFrame();
+                yield return new WaitForFixedUpdate();
             }
 
             var lazCoordinatorBehaviour = GameObject.FindObjectOfType<LazCoordinatorBehaviour>();
@@ -75,7 +75,7 @@ namespace Tests
         {
             for (int i = 0; i < 5; i++)
             {
-                yield return new WaitForEndOfFrame();
+                yield return new WaitForFixedUpdate();
             }
 
             var lazCoordinatorBehaviour = GameObject.FindObjectOfType<LazCoordinatorBehaviour>();

--- a/Assets/_Laz/Tests/LazMovementsBehaviourTests.cs
+++ b/Assets/_Laz/Tests/LazMovementsBehaviourTests.cs
@@ -32,7 +32,7 @@ namespace Tests
         {
             for (int i = 0; i < 5; i++)
             {
-                yield return new WaitForEndOfFrame();
+                yield return new WaitForFixedUpdate();
             }
 
             _lazCoordinatorBehaviour = GameObject.FindObjectOfType<LazCoordinatorBehaviour>();
@@ -52,7 +52,7 @@ namespace Tests
         {
             for (int i = 0; i < 5; i++)
             {
-                yield return new WaitForEndOfFrame();
+                yield return new WaitForFixedUpdate();
             }
 
             // Given
@@ -75,7 +75,7 @@ namespace Tests
         {
             for (int i = 0; i < 5; i++)
             {
-                yield return new WaitForEndOfFrame();
+                yield return new WaitForFixedUpdate();
             }
 
             // Given
@@ -98,7 +98,7 @@ namespace Tests
         {
             for (int i = 0; i < 5; i++)
             {
-                yield return new WaitForEndOfFrame();
+                yield return new WaitForFixedUpdate();
             }
 
             // Given
@@ -121,7 +121,7 @@ namespace Tests
         {
             for (int i = 0; i < 5; i++)
             {
-                yield return new WaitForEndOfFrame();
+                yield return new WaitForFixedUpdate();
             }
 
             // Given
@@ -147,7 +147,7 @@ namespace Tests
         {
             for (int i = 0; i < 5; i++)
             {
-                yield return new WaitForEndOfFrame();
+                yield return new WaitForFixedUpdate();
             }
 
             // Given

--- a/Assets/_Laz/Tests/LazoBehaviourTests.cs
+++ b/Assets/_Laz/Tests/LazoBehaviourTests.cs
@@ -33,7 +33,7 @@ namespace Tests
         {
             for (int i = 0; i < 5; i++)
             {
-                yield return new WaitForEndOfFrame();
+                yield return new WaitForFixedUpdate();
             }
 
             // When
@@ -84,7 +84,7 @@ namespace Tests
         {
             for (int i = 0; i < 5; i++)
             {
-                yield return new WaitForEndOfFrame();
+                yield return new WaitForFixedUpdate();
             }
 
             // When
@@ -134,7 +134,7 @@ namespace Tests
         {
             for (int i = 0; i < 5; i++)
             {
-                yield return new WaitForEndOfFrame();
+                yield return new WaitForFixedUpdate();
             }
 
             // When
@@ -167,7 +167,7 @@ namespace Tests
         {
             for (int i = 0; i < 5; i++)
             {
-                yield return new WaitForEndOfFrame();
+                yield return new WaitForFixedUpdate();
             }
 
             // When
@@ -198,7 +198,7 @@ namespace Tests
             lazoBehaviour.ResetLazoLimit();
             yield return new WaitForSeconds(0.1f);
             lazoBehaviour.ResetLazoLimit();
-            yield return new WaitForEndOfFrame();
+            yield return new WaitForFixedUpdate();
             
             Assert.IsTrue(_player.LazoTool.IsLazoing);
         }
@@ -208,14 +208,14 @@ namespace Tests
         {
             for (int i = 0; i < 5; i++)
             {
-                yield return new WaitForEndOfFrame();
+                yield return new WaitForFixedUpdate();
             }
 
             // When
             var amountToSpawn = 11;
             var lazoWallObjectPool = GameObject.FindObjectOfType<LazoWallObjectPooler>();
             lazoWallObjectPool.Initialize(amountToSpawn);
-            yield return new WaitForEndOfFrame();
+            yield return new WaitForFixedUpdate();
 
             // Then
             var actualResult = lazoWallObjectPool.gameObject.transform.childCount;

--- a/Assets/_Laz/Tests/LazoWithPlanetoidCollisionTests.cs
+++ b/Assets/_Laz/Tests/LazoWithPlanetoidCollisionTests.cs
@@ -33,7 +33,7 @@ namespace Tests
         {
             for (int i = 0; i < 5; i++)
             {
-                yield return new WaitForEndOfFrame();
+                yield return new WaitForFixedUpdate();
             }
 
             // When

--- a/Assets/_Laz/Tests/PatrolBehaviourTests.cs
+++ b/Assets/_Laz/Tests/PatrolBehaviourTests.cs
@@ -23,7 +23,7 @@ namespace Tests
         {
             for (int i = 0; i < 5; i++)
             {
-                yield return new WaitForEndOfFrame();
+                yield return new WaitForFixedUpdate();
             }
 
             var patrollingObject = GameObject.FindObjectOfType<PatrolBehaviour>();
@@ -38,7 +38,7 @@ namespace Tests
         {
             for (int i = 0; i < 5; i++)
             {
-                yield return new WaitForEndOfFrame();
+                yield return new WaitForFixedUpdate();
             }
 
             var patrollingObject = GameObject.FindObjectOfType<PatrolBehaviour>();
@@ -46,7 +46,7 @@ namespace Tests
             patrollingObject.Initialize();
             patrollingObject.CleanUp();
                 
-            yield return new WaitForEndOfFrame();
+            yield return new WaitForFixedUpdate();
             Assert.AreEqual(Vector3.zero, patrollingObject.transform.position, "Patrolling object should have moved");
         }
         
@@ -55,7 +55,7 @@ namespace Tests
         {
             for (int i = 0; i < 5; i++)
             {
-                yield return new WaitForEndOfFrame();
+                yield return new WaitForFixedUpdate();
             }
 
             var patrollingObject = GameObject.FindObjectOfType<PatrolBehaviour>();
@@ -63,7 +63,7 @@ namespace Tests
             patrollingObject.Initialize();
             patrollingObject.Reset();
                 
-            yield return new WaitForEndOfFrame();
+            yield return new WaitForSeconds(0);
             Assert.AreEqual(Vector3.left, patrollingObject.transform.position, "Patrolling object should have moved");
         }
     }


### PR DESCRIPTION
**JIRA Ticket**
https://perigongames.atlassian.net/browse/LAZ-122

**Description**
`WaitForEndFrame()` function does not work when ran with the -batchmode param for playmode tests (which is used by default in TeamCity). Read more [here](https://docs.unity3d.com/Manual/CLIBatchmodeCoroutines.html). So I switched all the functions with alternative WaitFor functions

